### PR TITLE
db dependencies 교체

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     // db
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    runtimeOnly("com.mysql:mysql-connector-j")
+    runtimeOnly ("org.mariadb.jdbc:mariadb-java-client:3.1.2")
 
     // security
     implementation("org.springframework.boot:spring-boot-starter-security")


### PR DESCRIPTION
- 클라우드 타입 배포를 위해 db driver를 mysql에서 mariadb로 교체