### PR TITLE
첫 번째 코트를 제외한 다른 코드를 예약할 수 없던 오류 해결

### DIFF
--- a/src/main/kotlin/com/example/gymi/domain/court/repository/CourtRepository.kt
+++ b/src/main/kotlin/com/example/gymi/domain/court/repository/CourtRepository.kt
@@ -8,5 +8,5 @@ import javax.persistence.LockModeType
 
 interface CourtRepository : CrudRepository<Court, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    fun findCourtByIdAndCourtNumber(id: Long, courtNumber: CourtNumber): Court
+    fun findCourtByCourtNumber(courtNumber: CourtNumber): Court
 }

--- a/src/main/kotlin/com/example/gymi/domain/reservation/util/FindReservationCountUtil.kt
+++ b/src/main/kotlin/com/example/gymi/domain/reservation/util/FindReservationCountUtil.kt
@@ -10,5 +10,5 @@ class FindReservationCountUtil(
     private val courtRepository: CourtRepository
 ) {
     fun findReservationCount(courtNumber: CourtNumber): Court =
-        courtRepository.findCourtByIdAndCourtNumber(1L, courtNumber)
+        courtRepository.findCourtByCourtNumber(courtNumber)
 }


### PR DESCRIPTION
- 첫 번째 코트를 제외한 다른 코드를 예약할 수 없던 오류 해결